### PR TITLE
Add makefile - so that `make test_server` brings up a test server, as for sockjs-node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 source/_static*
 source/_templates*
 make.bat
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+PYTHON=python
+
+#### General
+
+all:
+	$(PYTHON) setup.py build
+
+clean:
+	rm -rf venv
+	find . -name \*.pyc | xargs --no-run-if-empty rm
+
+#### Dependencies
+
+test_deps: venv/.test_deps
+
+venv:
+	virtualenv venv
+	-rm distribute-*.tar.gz || true
+
+venv/.test_deps: venv
+	./venv/bin/pip install tornado
+	touch venv/.test_deps
+
+#### Development
+
+test_server: test_deps
+	PYTHONPATH=$(PWD) ./venv/bin/python examples/test/test.py


### PR DESCRIPTION
This is generally a good practice and would be cool if all sockjs servers had a test_server easily runnable. But it's nothing of a significant value, feel free to trash it.
