### PR TITLE
fix handler reference, self.handler would be None in this case

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -254,7 +254,7 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
                 logging.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
                               self.session_id,
                               self.conn_info.ip,
-                              self.handler.request.remote_ip
+                              handler.request.remote_ip
                               ))
 
                 handler.send_pack(proto.disconnect(2010, "Attempted to connect to session from different IP"))


### PR DESCRIPTION
This was generating a traceback for us: (sanitized)

2012-03-27_08:48:56.81814 HTTPRequest(protocol='https', host='X', method='GET', uri='/sock/298/5l9ylxoa/htmlfile?c=_jp.avhahyr', version='HTTP/1.1', remote_ip='117.120.16.X', body='', headers={'Accept-Language': 'en-AU', 'Accept-Encoding': 'gzip, deflate', 'X-Forwarded-For': '117.120.16.X', 'Host': 'X', 'Accept': '_/_', 'User-Agent': 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; MS-RTC LM 8)', 'Connection': 'Keep-Alive', 'X-Forwarded-Proto': 'https', 'Referer': 'X/sock/iframe.html', 'Cookie': 'JSESSIONID=dummy'})
2012-03-27_08:48:56.81816 Traceback (most recent call last):
2012-03-27_08:48:56.81816   File "libs/tornado/tornado/web.py", line 1074, in wrapper
2012-03-27_08:48:56.81817     return method(self, _args, *_kwargs)
2012-03-27_08:48:56.81818   File "libs/sockjs-tornado/sockjs/tornado/transports/htmlfile.py", line 60, in get
2012-03-27_08:48:56.81820     if not self._attach_session(session_id):
2012-03-27_08:48:56.81821   File "libs/sockjs-tornado/sockjs/tornado/transports/pollingbase.py", line 30, in _attach_session
2012-03-27_08:48:56.81822     if not session.set_handler(self, start_heartbeat):
2012-03-27_08:48:56.81823   File "libs/sockjs-tornado/sockjs/tornado/session.py", line 257, in set_handler
2012-03-27_08:48:56.81823     self.handler.request.remote_ip
2012-03-27_08:48:56.81824 AttributeError: 'NoneType' object has no attribute 'request'
2012-03-27_08:48:56.81825 ERROR:root:Cannot send error response after headers written
