### PR TITLE
Fixed #20, added whitelist of exposed headers

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -24,11 +24,21 @@ class ConnectionInfo(object):
         Collection of cookies
     `arguments`
         Collection of the query string arguments
+    `headers`
+        Collection of explicitly exposed headers from the request including:
+        origin, referer, x-forward-for (and associated headers)
     """
-    def __init__(self, ip, cookies, arguments):
+    _exposed_headers = set(['referer', 'x-client-ip', 'x-forwarded-for',
+                            'x-cluster-client-ip', 'via', 'x-real-ip'])
+    def __init__(self, ip, cookies, arguments, headers):
         self.ip = ip
         self.cookies = cookies
         self.arguments = arguments
+        self.headers = {}
+
+        for header in headers:
+            if header.lower() in ConnectionInfo._exposed_headers:
+                self.headers[header] = headers[header]
 
     def get_argument(self, name):
         """Return single argument by name"""
@@ -40,6 +50,10 @@ class ConnectionInfo(object):
     def get_cookie(self, name):
         """Return single cookie by its name"""
         return self.cookies.get(name)
+
+    def get_header(self, name):
+        """Return single header by its name"""
+        return self.headers.get(name)
 
 
 # Session states

--- a/sockjs/tornado/transports/base.py
+++ b/sockjs/tornado/transports/base.py
@@ -13,7 +13,8 @@ class BaseTransportMixin(object):
         """Return `ConnectionInfo` object from current transport"""
         return session.ConnectionInfo(self.request.remote_ip,
                                       self.request.cookies,
-                                      self.request.arguments)
+                                      self.request.arguments,
+                                      self.request.headers)
 
     def session_closed(self):
         """Called by the session, when it gets closed"""


### PR DESCRIPTION
exposes useful headers in the connection info object: 'referer', 'x-client-ip',
'x-forwarded-for', 'x-cluster-client-ip', 'via', 'x-real-ip'
