### PR TITLE
Added the request path to the ConnectionInfo class

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -27,14 +27,17 @@ class ConnectionInfo(object):
     `headers`
         Collection of explicitly exposed headers from the request including:
         origin, referer, x-forward-for (and associated headers)
+    `path`
+        Request uri path
     """
     _exposed_headers = set(['referer', 'x-client-ip', 'x-forwarded-for',
                             'x-cluster-client-ip', 'via', 'x-real-ip'])
-    def __init__(self, ip, cookies, arguments, headers):
+    def __init__(self, ip, cookies, arguments, headers, path):
         self.ip = ip
         self.cookies = cookies
         self.arguments = arguments
         self.headers = {}
+        self.path = path
 
         for header in headers:
             if header.lower() in ConnectionInfo._exposed_headers:

--- a/sockjs/tornado/transports/base.py
+++ b/sockjs/tornado/transports/base.py
@@ -14,7 +14,8 @@ class BaseTransportMixin(object):
         return session.ConnectionInfo(self.request.remote_ip,
                                       self.request.cookies,
                                       self.request.arguments,
-                                      self.request.headers)
+                                      self.request.headers,
+                                      self.request.path)
 
     def session_closed(self):
         """Called by the session, when it gets closed"""


### PR DESCRIPTION
This provides similar functionality to the sockjs-node implementation (https://github.com/sockjs/sockjs-node/blob/master/src/transport.coffee#L123)
