### PR TITLE
small bugfix in multiplex example

### DIFF
--- a/examples/multiplex/multiplex.py
+++ b/examples/multiplex/multiplex.py
@@ -67,9 +67,9 @@ class MultiplexConnection(conn.SockJSConnection):
 
                 self.endpoints[chan] = session
 
-        def on_close(self):
-            for ep in self.endpoints:
-                ep._close()
+    def on_close(self):
+        for chan in self.endpoints:
+            self.endpoints[chan]._close()
 
     @classmethod
     def get(cls, **kwargs):


### PR DESCRIPTION
The on_close method of MultiplexConnection was indented once too many times so it wasn't being called correctly. And the loop to close the endpoints once it was being called was trying to close the key of the dict vs the endpoint session obj. So fixed indent and updated close logic. 
