### PR TITLE
Missed send_message method argument.

### DIFF
--- a/sockjs/tornado/transports/rawwebsocket.py
+++ b/sockjs/tornado/transports/rawwebsocket.py
@@ -15,7 +15,7 @@ from sockjs.tornado.transports import base
 class RawSession(session.BaseSession):
     """Raw session without any sockjs protocol encoding/decoding. Simply
     works as a proxy between `SockJSConnection` class and `RawWebSocketTransport`."""
-    def send_message(self, msg, binary=False):
+    def send_message(self, msg, stats=True, binary=False):
         self.handler.send_pack(msg, binary)
 
     def on_message(self, msg):


### PR DESCRIPTION
Now you will **not** get error when using raw sockets and calling **broadcast** method.
