### PR TITLE
RawWebSocketTransport can create an invalid (open, handler-less) session

### DIFF
--- a/sockjs/tornado/transports/rawwebsocket.py
+++ b/sockjs/tornado/transports/rawwebsocket.py
@@ -60,7 +60,6 @@ class RawWebSocketTransport(websocket.WebSocketHandler, base.BaseTransportMixin)
             logging.exception('RawWebSocket')
 
             # Close running connection
-            self._detach()
             self.abort_connection()
 
     def on_close(self):


### PR DESCRIPTION
If there is an exception during session.on_message, RawWebSocketTransport is catching it and aborting the connection.  However, it is also detaching the session before aborting, so when on_close get's called, session is already None.  In this instance, the session never gets closed so the application doesn't have a chance to do any cleanup.
