### PR TITLE
Modified to work without setuptools if its not available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,12 @@ import os
 try:
     from setuptools import setup, find_packages
 except ImportError:
-    from distribute_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
-
+    try:
+        from distribute_setup import use_setuptools
+        use_setuptools()
+        from setuptools import setup, find_packages
+    except ImportError:
+        from distutils.core import setup
 try:
     license = open('LICENSE').read()
 except:

--- a/sockjs/__init__.py
+++ b/sockjs/__init__.py
@@ -1,1 +1,5 @@
-__import__('pkg_resources').declare_namespace(__name__)
+try:
+  __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+  from pkgutil import extend_path
+  __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
Was using tornado on a small embedded router, doesn't support setuptools. Tornado has a fall-back option, now sockjs does.
