### PR TITLE
abort_connection is missing.

### DIFF
--- a/sockjs/tornado/websocket.py
+++ b/sockjs/tornado/websocket.py
@@ -2,6 +2,10 @@ from tornado import websocket, escape
 
 
 class SockJSWebSocketHandler(websocket.WebSocketHandler):
+
+    def abort_connection(self):
+        self.ws_connection._abort()
+
     def _execute(self, transforms, *args, **kwargs):
         # Websocket only supports GET method
         if self.request.method != "GET":


### PR DESCRIPTION
When an exception occurs, both RawWebSocketTransport and WebSocketTransport try to call self.abort_connection, which used to be defined on SockJSWebSocketHandler, when it still extended tornado.RequestHandler. I've resurrected the method, to avoid raising another exception inside the exception handler.
