### PR TITLE
Fixed: sockjs can send only strings on python 3+

### DIFF
--- a/sockjs/tornado/util.py
+++ b/sockjs/tornado/util.py
@@ -6,9 +6,9 @@ if PY3:
     MAXSIZE = sys.maxsize
 
     def bytes_to_str(b):
-        if isinstance(b, str):
-            return b
-        return str(b, 'utf8')
+        if isinstance(b, bytes):
+            return str(b, 'utf8')
+        return b
 
     def str_to_bytes(s):
         if isinstance(s, bytes):


### PR DESCRIPTION
In session.py:324

``` python
self.send_jsonified(proto.json_encode(bytes_to_str(msg)), stats)
```

When msg is not bytes(for example it's dict) you get exception cause bytes_to_str() tries to encode dict to utf-8 :+1:

Tested on Python 3.3
