### PR TITLE
Add the Python version and license classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,16 @@ distutils.core.setup(
     license=license,
     description='SockJS python server implementation on top of Tornado framework',
     long_description=desc(),
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
     requires=['tornado'],
     install_requires=[
         'tornado >= 2.1.1'


### PR DESCRIPTION
This lists the Python version and license classifiers in setup.py to have them show on PyPi, etc.

The supported Python versions are based on Tornado's setup.py. If sockjs-tornado doesn't support all of 2.6, 2.7, 3.2 and 3.3, please let me know and I'll update the patch.
