### PR TITLE
Include LICENSE file in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
+include LICENSE
 include README.rst
-


### PR DESCRIPTION
The source tree contains a file with this code's license, but MANIFEST.in doesn't include that in source distributions.  Assuming you're using setup.py to build your zip files, this should fix that.
