### PR TITLE
Using tornado.general logging stream instead of the default one

### DIFF
--- a/sockjs/tornado/basehandler.py
+++ b/sockjs/tornado/basehandler.py
@@ -14,6 +14,7 @@ from tornado.web import asynchronous, RequestHandler
 
 CACHE_TIME = 31536000
 
+LOG = logging.getLogger("tornado.general")
 
 class BaseHandler(RequestHandler):
     """Base request handler with set of helpers."""
@@ -86,7 +87,7 @@ class BaseHandler(RequestHandler):
             # We don't want to raise IOError exception if finish() call fails.
             # It can happen if connection is set to Keep-Alive, but client
             # closes connection after receiving response.
-            logging.debug('Ignoring IOError in safe_finish()')
+            LOG.debug('Ignoring IOError in safe_finish()')
             pass
 
 

--- a/sockjs/tornado/periodic.py
+++ b/sockjs/tornado/periodic.py
@@ -10,6 +10,7 @@
 import time
 import logging
 
+LOG = logging.getLogger("tornado.general")
 
 class Callback(object):
     """Custom implementation of the Tornado.Callback with support
@@ -69,7 +70,7 @@ class Callback(object):
         except (KeyboardInterrupt, SystemExit):
             raise
         except:
-            logging.error("Error in periodic callback", exc_info=True)
+            LOG.error("Error in periodic callback", exc_info=True)
 
         if self._running:
             self.start(next_call)

--- a/sockjs/tornado/proto.py
+++ b/sockjs/tornado/proto.py
@@ -7,6 +7,8 @@
 """
 import logging
 
+LOG = logging.getLogger("tornado.general")
+
 # TODO: Add support for ujson module once they can accept unicode strings
 
 # Try to find best json encoder available
@@ -18,12 +20,12 @@ try:
     json_decode = lambda data: simplejson.loads(data)
     JSONDecodeError = ValueError
 
-    logging.debug('sockjs.tornado will use simplejson module')
+    LOG.debug('sockjs.tornado will use simplejson module')
 except ImportError:
     # Use slow json
     import json
 
-    logging.debug('sockjs.tornado will use json module')
+    LOG.debug('sockjs.tornado will use json module')
 
     json_encode = lambda data: json.dumps(data, separators=(',', ':'))
     json_decode = lambda data: json.loads(data)

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -11,6 +11,8 @@ import logging
 from sockjs.tornado import sessioncontainer, periodic, proto
 from sockjs.tornado.util import bytes_to_str
 
+LOG = logging.getLogger("tornado.general")
+
 class ConnectionInfo(object):
     """Connection information object.
 
@@ -138,7 +140,7 @@ class BaseSession(object):
             try:
                 self.conn.on_close()
             except:
-                logging.debug("Failed to call on_close().", exc_info=True)
+                LOG.debug("Failed to call on_close().", exc_info=True)
             finally:
                 self.state = CLOSED
                 self.close_reason = (code, message)
@@ -270,7 +272,7 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
         if self._verify_ip and self.conn_info is not None:
             # If IP address doesn't match - refuse connection
             if handler.request.remote_ip != self.conn_info.ip:
-                logging.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
+                LOG.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
                               self.session_id,
                               self.conn_info.ip,
                               handler.request.remote_ip

--- a/sockjs/tornado/transports/jsonp.py
+++ b/sockjs/tornado/transports/jsonp.py
@@ -13,6 +13,8 @@ from sockjs.tornado import proto
 from sockjs.tornado.transports import pollingbase
 from sockjs.tornado.util import bytes_to_str, unquote_plus
 
+LOG = logging.getLogger("tornado.general")
+
 class JSONPTransport(pollingbase.PollingTransportBase):
     name = 'jsonp'
 
@@ -84,7 +86,7 @@ class JSONPSendHandler(pollingbase.PollingTransportBase):
         ctype = self.request.headers.get('Content-Type', '').lower()
         if ctype == 'application/x-www-form-urlencoded':
             if not data.startswith('d='):
-                logging.exception('jsonp_send: Invalid payload.')
+                LOG.exception('jsonp_send: Invalid payload.')
 
                 self.write("Payload expected.")
                 self.set_status(500)
@@ -93,7 +95,7 @@ class JSONPSendHandler(pollingbase.PollingTransportBase):
             data = unquote_plus(data[2:])
 
         if not data:
-            logging.debug('jsonp_send: Payload expected.')
+            LOG.debug('jsonp_send: Payload expected.')
 
             self.write("Payload expected.")
             self.set_status(500)
@@ -103,7 +105,7 @@ class JSONPSendHandler(pollingbase.PollingTransportBase):
             messages = proto.json_decode(data)
         except:
             # TODO: Proper error handling
-            logging.debug('jsonp_send: Invalid json encoding')
+            LOG.debug('jsonp_send: Invalid json encoding')
 
             self.write("Broken JSON encoding.")
             self.set_status(500)
@@ -112,7 +114,7 @@ class JSONPSendHandler(pollingbase.PollingTransportBase):
         try:
             session.on_messages(messages)
         except Exception:
-            logging.exception('jsonp_send: on_message() failed')
+            LOG.exception('jsonp_send: on_message() failed')
 
             session.close()
 

--- a/sockjs/tornado/transports/rawwebsocket.py
+++ b/sockjs/tornado/transports/rawwebsocket.py
@@ -11,6 +11,7 @@ import socket
 from sockjs.tornado import websocket, session
 from sockjs.tornado.transports import base
 
+LOG = logging.getLogger("tornado.general")
 
 class RawSession(session.BaseSession):
     """Raw session without any sockjs protocol encoding/decoding. Simply
@@ -57,7 +58,7 @@ class RawWebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransport
         try:
             self.session.on_message(message)
         except Exception:
-            logging.exception('RawWebSocket')
+            LOG.exception('RawWebSocket')
 
             # Close running connection
             self.abort_connection()

--- a/sockjs/tornado/transports/websocket.py
+++ b/sockjs/tornado/transports/websocket.py
@@ -12,6 +12,7 @@ from sockjs.tornado import proto, websocket
 from sockjs.tornado.transports import base
 from sockjs.tornado.util import bytes_to_str
 
+LOG = logging.getLogger("tornado.general")
 
 class WebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransportMixin):
     """Websocket transport"""
@@ -60,7 +61,7 @@ class WebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransportMix
             else:
                 self.session.on_messages((msg,))
         except Exception:
-            logging.exception('WebSocket')
+            LOG.exception('WebSocket')
 
             # Close session on exception
             #self.session.close()

--- a/sockjs/tornado/transports/xhr.py
+++ b/sockjs/tornado/transports/xhr.py
@@ -13,6 +13,8 @@ from sockjs.tornado import proto
 from sockjs.tornado.transports import pollingbase
 from sockjs.tornado.util import bytes_to_str
 
+LOG = logging.getLogger("tornado.general")
+
 class XhrPollingTransport(pollingbase.PollingTransportBase):
     """xhr-polling transport implementation"""
     name = 'xhr'
@@ -83,7 +85,7 @@ class XhrSendHandler(pollingbase.PollingTransportBase):
         try:
             session.on_messages(messages)
         except Exception:
-            logging.exception('XHR incoming')
+            LOG.exception('XHR incoming')
             session.close()
 
             self.set_status(500)


### PR DESCRIPTION
Sockjs-tornado uses the default logger from `logging` module and it will therefore override pretty log format set by Tornado on startup. This commit makes the application code log messages to the `tornado.general` stream, thus preserving the log format (and behaving coherently with Tornado).

Please find an explanation of logging in Tornado [here](http://www.tornadoweb.org/en/stable/log.html#module-tornado.log)
