### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ source/_static*
 source/_templates*
 make.bat
 venv
+*.egg-info


### PR DESCRIPTION
When using buildout with mr. developer set to checkout the source from github, there are errors caused by the created sockjs_tornado.egg-info when attempting to rebuild the buildout. The repo has uncommitted changes.

You can see the fix [here](http://buildoutcoredev.readthedocs.org/en/latest/issues.html#dirty-packages). It says svn but the idea is the same.

This change will allow buildout to work as expected.
