### PR TITLE
accept cross-origin websocket connections by default

### DIFF
--- a/sockjs/tornado/router.py
+++ b/sockjs/tornado/router.py
@@ -34,7 +34,10 @@ DEFAULT_SETTINGS = {
     'disable_nagle': True,
     # Enable IP checks for polling transports. If enabled, all subsequent
     # polling calls should be from the same IP address.
-    'verify_ip': True
+    'verify_ip': True,
+    # list of allowed origins for websocket connections
+    # or "*" - accept all websocket connections
+    'websocket_allow_origin': "*"
     }
 
 GLOBAL_HANDLERS = [

--- a/sockjs/tornado/websocket.py
+++ b/sockjs/tornado/websocket.py
@@ -1,7 +1,29 @@
 from tornado import websocket, escape
 
+try:
+    from urllib.parse import urlparse # py3
+except ImportError:
+    from urlparse import urlparse # py2
+
 
 class SockJSWebSocketHandler(websocket.WebSocketHandler):
+
+    def check_origin(self, origin):
+        # let tornado first check if connection from the same domain
+        same_domain = super(SockJSWebSocketHandler, self).check_origin(origin)
+        if same_domain:
+            return True
+
+        # this is cross-origin connection - check using SockJS server settings
+        allow_origin = self.server.settings.get("websocket_allow_origin", "*")
+        if allow_origin == "*":
+            return True
+        else:
+            parsed_origin = urlparse(origin)
+            origin = parsed_origin.netloc
+            origin = origin.lower()
+            return origin in allow_origin
+
     def abort_connection(self):
         self.ws_connection._abort()
 


### PR DESCRIPTION
fixes #63. Tornado 4 introduced 403 status code in case of cross-origin websocket connections. Here `websocket_allow_origin` SockJS server option was introduced. By default its value is "*" - i.e. accept all websocket connections. But it can also be a list of allowed origins
