### PR TITLE
Websocket instance can exist without a stream

### DIFF
--- a/sockjs/tornado/websocket.py
+++ b/sockjs/tornado/websocket.py
@@ -41,7 +41,7 @@ class SockJSWebSocketHandler(websocket.WebSocketHandler):
 
         # Upgrade header should be present and should be equal to WebSocket
         if self.request.headers.get("Upgrade", "").lower() != "websocket":
-            self.set_status(405)
+            self.set_status(400)
             self.finish(escape.utf8(
                 "Connection: Close\r\n"
                 "\r\n"


### PR DESCRIPTION
Recent Tornado WebSocketHandler seems to have a different way to express status when the stream is absent.
