### PR TITLE
We have seen cases where verify_ip fails on ipv4 vs ipv6 expression of localhost

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -267,7 +267,8 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
 
         if self._verify_ip and self.conn_info is not None:
             # If IP address doesn't match - refuse connection
-            if handler.request.remote_ip != self.conn_info.ip:
+            localv6 = lambda ip: '127.0.0.1' if ip == '::1' else ip
+            if localv6(handler.request.remote_ip) != localv6(self.conn_info.ip):
                 LOG.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
                               self.session_id,
                               self.conn_info.ip,


### PR DESCRIPTION
Eg from our stderr:
ERROR:tornado.general:Attempted to attach to session 7ceo057h (::1) from different IP (127.0.0.1)
ERROR:tornado.general:Attempted to attach to session 60qsy81d (127.0.0.1) from different IP (::1)
I do a simple normalization to the ipv4 version: I'm sure something smarter could be done.
This is at least a way to pinpoint the issue.
