### PR TITLE
Use another cdn for sockjs_url option

### DIFF
--- a/sockjs/tornado/router.py
+++ b/sockjs/tornado/router.py
@@ -22,7 +22,7 @@ DEFAULT_SETTINGS = {
     # Enabled protocols
     'disabled_transports': [],
     # SockJS location
-    'sockjs_url': 'http://cdn.sockjs.org/sockjs-0.3.min.js',
+    'sockjs_url': 'https://cdn.jsdelivr.net/sockjs/0.3/sockjs.min.js',
     # Max response body size
     'response_limit': 128 * 1024,
     # Enable or disable JSESSIONID cookie handling


### PR DESCRIPTION
It seems that SockJS CDN will be removed with 1.0 release - https://github.com/sockjs/sockjs-client/issues/198
