### PR TITLE
Flush outgoing queue before closing session

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -281,7 +281,7 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
                 handler.send_pack(proto.disconnect(2010, "Attempted to connect to session from different IP"))
                 return False
 
-        if self.state == CLOSING or self.state == CLOSED:
+        if (self.state == CLOSING or self.state == CLOSED) and not self.send_queue:
             handler.send_pack(proto.disconnect(*self.get_close_reason()))
             return False
 


### PR DESCRIPTION
Fixes mrjoes/sockjs-tornado#44.

Allow sessions to be joined if they are in a closing or closed state but still have data left on their send queue. This allows the send queue to be flushed by the current request for the session, and the next request for the session will be rejected since the send queue is now cleared.