### PR TITLE
Removing whitelist of headers in the connection info

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -13,6 +13,7 @@ from sockjs.tornado.util import bytes_to_str
 
 LOG = logging.getLogger("tornado.general")
 
+
 class ConnectionInfo(object):
     """Connection information object.
 
@@ -27,23 +28,17 @@ class ConnectionInfo(object):
     `arguments`
         Collection of the query string arguments
     `headers`
-        Collection of explicitly exposed headers from the request including:
-        origin, referer, x-forward-for (and associated headers)
+        Collection of headers sent by the browser that established this
+        connection
     `path`
         Request uri path
     """
-    _exposed_headers = set(['referer', 'x-client-ip', 'x-forwarded-for',
-                            'x-cluster-client-ip', 'via', 'x-real-ip'])
     def __init__(self, ip, cookies, arguments, headers, path):
         self.ip = ip
         self.cookies = cookies
         self.arguments = arguments
-        self.headers = {}
+        self.headers = headers
         self.path = path
-
-        for header in headers:
-            if header.lower() in ConnectionInfo._exposed_headers:
-                self.headers[header] = headers[header]
 
     def get_argument(self, name):
         """Return single argument by name"""


### PR DESCRIPTION
* Related issue: #62 

All headers are now exposed in the ConnectionInfo object and can be used in the SockJSConnection subclasses.

I did not get the reason why you made the choice of _not_ exposing all headers by default. If there is a good one, I made another PR that is keeping the exposed headers set but allows user ton configure it. See: #85 