### PR TITLE
Provide configuration capability to the exposed headers set from ConnectionInfo

### DIFF
--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -13,6 +13,7 @@ from sockjs.tornado.util import bytes_to_str
 
 LOG = logging.getLogger("tornado.general")
 
+
 class ConnectionInfo(object):
     """Connection information object.
 
@@ -29,21 +30,19 @@ class ConnectionInfo(object):
     `headers`
         Collection of explicitly exposed headers from the request including:
         origin, referer, x-forward-for (and associated headers)
+        Call `expose_header` to explicitly expose other headers.
     `path`
         Request uri path
     """
     _exposed_headers = set(['referer', 'x-client-ip', 'x-forwarded-for',
                             'x-cluster-client-ip', 'via', 'x-real-ip'])
+
     def __init__(self, ip, cookies, arguments, headers, path):
         self.ip = ip
         self.cookies = cookies
         self.arguments = arguments
-        self.headers = {}
+        self.headers = headers
         self.path = path
-
-        for header in headers:
-            if header.lower() in ConnectionInfo._exposed_headers:
-                self.headers[header] = headers[header]
 
     def get_argument(self, name):
         """Return single argument by name"""
@@ -58,7 +57,11 @@ class ConnectionInfo(object):
 
     def get_header(self, name):
         """Return single header by its name"""
-        return self.headers.get(name)
+        return self.headers.get(name) if name in ConnectionInfo._exposed_headers else None
+
+    @classmethod
+    def expose_header(cls, name):
+        cls._exposed_headers.add(name)
 
 
 # Session states


### PR DESCRIPTION
* Related issue: #62 

Added `expose_header` classmethod to ConnectionInfo to allow configuring explicitly exposed headers. Usage is as follow:

```
from sockjs.tornado.session import ConnectionInfo
from sockjs.tornado import SockJSConnection

ConnectionInfo.expose_header('Host')

class BaseConnection(SockJSConnection):
    def on_open(self, request):
        print request.get_header('Host')
```

`expose_header` being a classmethod, the exposed headers are shared by all instances of ConnectionInfo and the function can also be called from any instance of the class. Subsequent calls to `expose_header` given the same header name won't do anything.

Note: a simplest way to address to related issue is to remove the white list of exposed headers. If this is a preferable way, another PR exists here: #84
