### PR TITLE
[FIX] When client close the websocket connection incorrectly, the sockjs server don't release the connection.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def desc():
 
 distutils.core.setup(
     name='sockjs-tornado',
-    version='1.0.2',
+    version='1.0.3',
     author='Serge S. Koval',
     author_email='serge.koval@gmail.com',
     packages=['sockjs', 'sockjs.tornado', 'sockjs.tornado.transports'],

--- a/sockjs/tornado/conn.py
+++ b/sockjs/tornado/conn.py
@@ -26,17 +26,24 @@ class SockJSConnection(object):
         You can also throw Tornado HTTPError to close connection.
 
         `request`
-            ``ConnectionInfo`` object which contains caller IP address, query string
-            parameters and cookies associated with this request (if any).
+            ``ConnectionInfo`` object which contains caller IP address, query
+            string parameters and cookies associated with this request (if any).
         """
         pass
 
     def on_message(self, message):
-        """Default on_message handler. Must be overridden in your application"""
+        """Default on_message handler. Must be overridden in your application
+        """
         raise NotImplementedError()
 
+    def on_heartbeat(self):
+        """Default on_heartbeat handler
+        """
+        pass
+
     def on_close(self):
-        """Default on_close handler."""
+        """Default on_close handler.
+        """
         pass
 
     def send(self, message, binary=False):

--- a/sockjs/tornado/router.py
+++ b/sockjs/tornado/router.py
@@ -19,6 +19,8 @@ DEFAULT_SETTINGS = {
     # Heartbeat time in seconds. Do not change this value unless
     # you absolutely sure that new value will work.
     'heartbeat_delay': 25,
+    # Websocket heartbeat check interval
+    'heartbeat_check_delay': 10,
     # Enabled protocols
     'disabled_transports': [],
     # SockJS location
@@ -38,7 +40,7 @@ DEFAULT_SETTINGS = {
     # list of allowed origins for websocket connections
     # or "*" - accept all websocket connections
     'websocket_allow_origin': "*"
-    }
+}
 
 GLOBAL_HANDLERS = [
     ('xhr_send', transports.XhrSendHandler),
@@ -128,7 +130,7 @@ class SockJSRouter(object):
                 (r'%s/%s$' % (base, k),
                  v,
                  dict(server=self))
-                )
+            )
 
         # Generate static URLs
         self._transport_urls.extend([('%s%s' % (prefix, k), v, dict(server=self))

--- a/sockjs/tornado/router.py
+++ b/sockjs/tornado/router.py
@@ -8,7 +8,14 @@
 
 from tornado import ioloop, version_info
 
-from sockjs.tornado import transports, session, sessioncontainer, static, stats, proto
+from sockjs.tornado import (
+    transports,
+    session,
+    sessioncontainer,
+    static,
+    stats,
+    proto
+)
 
 
 DEFAULT_SETTINGS = {

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -423,7 +423,8 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
         If server doesn't recv heartbeat packet from client
         in the interval of two heartbeat, it will close this session.
         """
-        LOG.info('recv heartbeat packet from client timeout')
+        LOG.debug('recv heartbeat packet from client timeout')
+        self.stop_heartbeat()
         self.handler.abort_connection()
 
     def on_messages(self, msg_list):

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -409,8 +409,15 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
     def _heartbeat(self):
         """Heartbeat callback"""
         if self.handler is not None:
-            self.handler.send_pack(proto.HEARTBEAT)
-            if self.handler.name.endswith("websocket"):
+            name = self.handler.name
+
+            # Origin websocket using ping/pong as heartbeat.
+            if name == "rawwebsocket":
+                self.handler.ping('ping')
+            else:
+                self.handler.send_pack(proto.HEARTBEAT)
+
+            if name == "websocket":
                 self._check_heartbeat_timer = self.server.io_loop.call_later(
                     self._heartbeat_check_delay,
                     self._check_heartbeat)

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -443,5 +443,6 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
                     if self._check_heartbeat_timer is not None:
                         self.server.io_loop.remove_timeout(
                             self._check_heartbeat_timer)
+                    self.conn.on_heartbeat()
                 else:
                     self.conn.on_message(msg)

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -229,7 +229,9 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
 
         # Heartbeat related stuff
         self._heartbeat_timer = None
+        self._check_heartbeat_timer = None
         self._heartbeat_interval = self.server.settings['heartbeat_delay'] * 1000
+        self._heartbeat_check_delay = self.server.settings['heartbeat_check_delay']
 
         self._immediate_flush = self.server.settings['immediate_flush']
         self._pending_flush = False
@@ -268,12 +270,10 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
             # If IP address doesn't match - refuse connection
             if handler.request.remote_ip != self.conn_info.ip:
                 LOG.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
-                              self.session_id,
-                              self.conn_info.ip,
-                              handler.request.remote_ip
-                              ))
+                    self.session_id, self.conn_info.ip, handler.request.remote_ip))
 
-                handler.send_pack(proto.disconnect(2010, "Attempted to connect to session from different IP"))
+                handler.send_pack(proto.disconnect(
+                    2010, "Attempted to connect to session from different IP"))
                 return False
 
         if (self.state == CLOSING or self.state == CLOSED) and not self.send_queue:
@@ -309,6 +309,7 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
 
         self.promote()
         self.stop_heartbeat()
+        self.stop_check_heartbeat()
 
     def send_message(self, msg, stats=True, binary=False):
         """Send or queue outgoing message
@@ -385,6 +386,7 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
         self._heartbeat_timer = periodic.Callback(self._heartbeat,
                                                   self._heartbeat_interval,
                                                   self.server.io_loop)
+
         self._heartbeat_timer.start()
 
     def stop_heartbeat(self):
@@ -392,6 +394,12 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
         if self._heartbeat_timer is not None:
             self._heartbeat_timer.stop()
             self._heartbeat_timer = None
+
+    def stop_check_heartbeat(self):
+        """Stop active heartbeat check timer"""
+        if self._check_heartbeat_timer is not None:
+            self.server.io_loop.remove_timeout(self._check_heartbeat_timer)
+            self._check_heartbeat_timer = None
 
     def delay_heartbeat(self):
         """Delay active heartbeat"""
@@ -402,8 +410,21 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
         """Heartbeat callback"""
         if self.handler is not None:
             self.handler.send_pack(proto.HEARTBEAT)
+            if self.handler.name.endswith("websocket"):
+                self._check_heartbeat_timer = self.server.io_loop.call_later(
+                    self._heartbeat_check_delay,
+                    self._check_heartbeat)
         else:
             self.stop_heartbeat()
+
+    def _check_heartbeat(self):
+        """Check heartbeat.
+
+        If server doesn't recv heartbeat packet from client
+        in the interval of two heartbeat, it will close this session.
+        """
+        LOG.info('recv heartbeat packet from client timeout')
+        self.handler.abort_connection()
 
     def on_messages(self, msg_list):
         """Handle incoming messages
@@ -415,4 +436,10 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
 
         for msg in msg_list:
             if self.state == OPEN:
-                self.conn.on_message(msg)
+                if msg == proto.HEARTBEAT:
+                    # When recv `heartbeat` from client,
+                    # remove the `_check_heartbeat_timer` from ioloop.
+                    self.server.io_loop.remove_timeout(
+                        self._check_heartbeat_timer)
+                else:
+                    self.conn.on_message(msg)

--- a/sockjs/tornado/session.py
+++ b/sockjs/tornado/session.py
@@ -440,7 +440,8 @@ class Session(BaseSession, sessioncontainer.SessionMixin):
                 if msg == proto.HEARTBEAT:
                     # When recv `heartbeat` from client,
                     # remove the `_check_heartbeat_timer` from ioloop.
-                    self.server.io_loop.remove_timeout(
-                        self._check_heartbeat_timer)
+                    if self._check_heartbeat_timer is not None:
+                        self.server.io_loop.remove_timeout(
+                            self._check_heartbeat_timer)
                 else:
                     self.conn.on_message(msg)


### PR DESCRIPTION
It will lead fd leak or memory leak in production environment.

I will show the detail of the problem later.