### PR TITLE
Allow Sec-WebSocket-Extensions: permessage-deflate

### DIFF
--- a/sockjs/tornado/websocket.py
+++ b/sockjs/tornado/websocket.py
@@ -7,6 +7,9 @@ except ImportError:
 
 
 class SockJSWebSocketHandler(websocket.WebSocketHandler):
+    def get_compression_options(self):
+        # let tornado use compression when Sec-WebSocket-Extensions:permessage-deflate is provided
+        return {}
 
     def check_origin(self, origin):
         # let tornado first check if connection from the same domain


### PR DESCRIPTION
Sec-WebSocket-Extensions:permessage-deflate is implemented in Tornado but is only enabled if get_compression_options is overridden. It sounds like a good idea to provide a sane default.