### PR TITLE
Let Tornado manage TCP_NODELAY of websocket

### DIFF
--- a/sockjs/tornado/transports/websocket.py
+++ b/sockjs/tornado/transports/websocket.py
@@ -29,7 +29,7 @@ class WebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransportMix
 
         # Disable nagle
         if self.server.settings['disable_nagle']:
-            self.stream.socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
+            self.stream.set_nodelay(True)
 
         # Handle session
         self.session = self.server.create_session(session_id, register=False)


### PR DESCRIPTION
As we can see from https://github.com/tornadoweb/tornado/blob/master/tornado/iostream.py#L1199-L1210, Tornado internal would only set TCP_NODELAY on IPv4/IPv6 socket. Re-using the logics shall not be a bad idea, right?
