### PR TITLE
Handle WebSocketClosedError and fix indentation error

### DIFF
--- a/sockjs/tornado/transports/htmlfile.py
+++ b/sockjs/tornado/transports/htmlfile.py
@@ -65,7 +65,7 @@ class HtmlFileTransport(streamingbase.StreamingTransportBase):
             return
 
         if CALLBACK_RE.search(callback):
-             self.write('invalid "callback" parameter')
+            self.write('invalid "callback" parameter')
             self.set_status(500)
             self.finish()
             return

--- a/sockjs/tornado/transports/websocket.py
+++ b/sockjs/tornado/transports/websocket.py
@@ -87,7 +87,7 @@ class WebSocketTransport(websocket.SockJSWebSocketHandler, base.BaseTransportMix
         # Send message
         try:
             self.write_message(message, binary)
-        except IOError:
+        except (IOError, websocket.WebSocketClosedError):
             self.server.io_loop.add_callback(self.on_close)
 
     def session_closed(self):


### PR DESCRIPTION
Using `sockjs-tornado==1.0.7` with `tornado==6.2`, we see millions of exceptions of the form:

```
  File "/site/venv/lib/python3.10/site-packages/sockjs/tornado/periodic.py", line 69, in _run
    next_call = self.callback()
  File "/site/venv/lib/python3.10/site-packages/sockjs/tornado/session.py", line 405, in _heartbeat
    self.handler.send_pack(proto.HEARTBEAT)
  File "/site/venv/lib/python3.10/site-packages/sockjs/tornado/transports/websocket.py", line 89, in send_pack
    self.write_message(message, binary)
  File "/site/venv/lib/python3.10/site-packages/tornado/websocket.py", line 336, in write_message
    raise WebSocketClosedError()
```

`sockjs-tornado` handles `IOError` but `tornado` is raising `WebSocketClosedError`. This PR handles both errors.

While fixing this, I also encountered and fixed this exception due to an incorrect indentation in `sockjs/tornado/transports/htmlfile.py`:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/cureatr/dev/cureatr/server/notification/web/notification_server.py", line 11, in <module>
    from sockjs.tornado import SockJSRouter
  File "/tmp/sockjs-tornado/sockjs/tornado/__init__.py", line 3, in <module>
    from .router import SockJSRouter
  File "/tmp/sockjs-tornado/sockjs/tornado/router.py", line 11, in <module>
    from sockjs.tornado import transports, session, sessioncontainer, static, stats, proto
  File "/tmp/sockjs-tornado/sockjs/tornado/transports/__init__.py", line 10, in <module>
    from .htmlfile import HtmlFileTransport
  File "/tmp/sockjs-tornado/sockjs/tornado/transports/htmlfile.py", line 69
    self.set_status(500)
                        ^
IndentationError: unindent does not match any outer indentation level
```